### PR TITLE
Make AbstractSorterViewHolder a open class

### DIFF
--- a/tableview/src/main/java/ph/ingenuity/tableview/adapter/recyclerview/holder/AbstractSorterViewHolder.kt
+++ b/tableview/src/main/java/ph/ingenuity/tableview/adapter/recyclerview/holder/AbstractSorterViewHolder.kt
@@ -32,7 +32,7 @@ import ph.ingenuity.tableview.feature.sort.SortState.UNSORTED
  * @author Jeremy Patrick Pacabis <jeremy@ingenuity.ph>
  * ph.ingenuity.tableview.adapter.recyclerview.holder <android-tableview-kotlin>
  */
-class AbstractSorterViewHolder(itemView: View) : AbstractViewHolder(itemView) {
+open class AbstractSorterViewHolder(itemView: View) : AbstractViewHolder(itemView) {
 
     var sortState = UNSORTED
         private set


### PR DESCRIPTION
It has to be `open` in order to extend it